### PR TITLE
my fix for troubles with VCSVimDiff against HEAD with cp1252 files

### DIFF
--- a/plugin/vcscommand.vim
+++ b/plugin/vcscommand.vim
@@ -980,6 +980,9 @@ function! s:VCSReview(...)  "{{{2
 		let resultBuffer = s:ExecuteVCSCommand('Review', a:000)
 		if resultBuffer > 0
 			let &filetype = getbufvar(b:VCSCommandOriginalBuffer, '&filetype')
+			" ans: {
+			let &fileencoding = getbufvar(b:VCSCommandOriginalBuffer, '&fileencoding')
+			" ans: }
 		endif
 		return resultBuffer
 	finally


### PR DESCRIPTION
I assume that somewhere after vim 8.0 vim stopped to guess fileencoding
of generated buffer with empty fileencoding option, or assumes that to
be utf8 internally. Anyway setting fileencoding explicitely on the
generated buffer fixes the diff.

Steps to reproduce:
1) Environment: cygwin with vim8.1 with patches 1-1772
2) mkdir tstvcscmd; cd tstvcscmd; git init . # Create empty git repository
3) for ((i = 1; i <= 200; i++)) ; do echo $i >> ./f; done; # prepare some file
4) printf '\xfc' >> f # insert "u umlaut"
5) for ((i = 200; i > 0; i--)) ; do echo $i >> ./f; done;
6) git add f
7) git ci -m 'f added'
8) cat f | sed -e '5,10d' > f.new ; mv f.new f # some modification
9) vim f -c 'VCSVimDiff'

Without patch in my environment "u umlaut" is recognized as change in my
working copy. With patch it is ignored (correctly).